### PR TITLE
Transfer UV data into double

### DIFF
--- a/lib/src/domains/forecast_weather.dart
+++ b/lib/src/domains/forecast_weather.dart
@@ -72,7 +72,7 @@ class ForecastWeather {
         jsonCurrentWeather?['feelslike_f'],
         jsonCurrentWeather?['vis_km'],
         jsonCurrentWeather?['vis_miles'],
-        jsonCurrentWeather?['uv'],
+        jsonCurrentWeather?['uv']?.toDouble(),
         jsonCurrentWeather?['gust_mph'],
         jsonCurrentWeather?['gust_kph'],
         airQuality);
@@ -119,7 +119,7 @@ class ForecastWeather {
           jsonDay?['daily_will_it_snow'],
           jsonDay?['daily_chance_of_snow'],
           dayCondition,
-          jsonDay?['uv']);
+          jsonDay?['uv']?.toDouble());
 
       // --- Astro.
 
@@ -182,7 +182,7 @@ class ForecastWeather {
             jsonHour['vis_miles'],
             jsonHour['gust_mph'],
             jsonHour['gust_kph'],
-            jsonHour['uv']);
+            jsonHour['uv']?.toDouble());
 
         hours.add(hour);
       });

--- a/lib/src/domains/realtime_weather.dart
+++ b/lib/src/domains/realtime_weather.dart
@@ -70,7 +70,7 @@ class RealtimeWeather {
         jsonCurrentWeather?['feelslike_f'],
         jsonCurrentWeather?['vis_km'],
         jsonCurrentWeather?['vis_miles'],
-        jsonCurrentWeather?['uv'],
+        jsonCurrentWeather?['uv']?.toDouble(),
         jsonCurrentWeather?['gust_mph'],
         jsonCurrentWeather?['gust_kph'],
         airQuality);


### PR DESCRIPTION
I often got UV values being zero, which were parse as int and caused error.
I have to use toDouble() to avoid this error